### PR TITLE
Edit applyOnDeep regex to match double digit index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.1]
+
+### Fixed
+
+- correct pttren regex in applyOnDeep method to match multi-digit numbers
+
 ## [4.2.0-rc2]
 
 ### Added

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -247,7 +247,7 @@ class Validator {
 
     Object.keys(notations).forEach((notation) => {
       attrs.forEach((attr) => {
-        const pttren = attr.replace(/\*/g, '[0-9+]');
+        const pttren = attr.replace(/\*/g, '[0-9]+');
 
         const results = notation.match(RegExp(`^${pttren}$`));
         if (results) {

--- a/test/nested.js
+++ b/test/nested.js
@@ -46,6 +46,14 @@ const input = {
             },
           ],
         },
+        { id: 14 },
+        { id: 15 },
+        { id: 16 },
+        { id: 17 },
+        { id: 18 },
+        { id: 19 },
+        { id: 20 },
+        { id: null }
       ],
     },
     {
@@ -203,6 +211,21 @@ describe('Nested', () => {
 
 
       v.errors.should.have.keys('cart.1.varients.0.colors.2.props.0.tags');
+    });
+
+    it('should fail with child required at array index > 9', async () => {
+      const v = new Validator(
+        input,
+        {
+          'cart.*.varients.*.id': 'required',
+        },
+      );
+
+      const matched = await v.check();
+
+      assert.equal(matched, false);
+
+      v.errors.should.have.keys('cart.0.varients.10.id');
     });
   });
 });


### PR DESCRIPTION
The pttren regex inside applyOnDeep method had a misplaced '+'.
Character was placed after the capture group to allow multiple digits to flag as a match.

Unit test added to verify that double digit array indices now match.