### PR TITLE
(Issue 52) Bugfix for unexpected TypeError when maxLength rule receives undefined input 

### DIFF
--- a/lib/rules/maxLength.js
+++ b/lib/rules/maxLength.js
@@ -6,7 +6,7 @@ module.exports = function maxLength({ attr, value, args }) {
     throw new Error(`Seed in maxLength rule for ${attr} must be a number.`);
   }
 
-  if (value.toString().length > parseInt(maxNum)) {
+  if (value && value.toString().length > parseInt(maxNum)) {
     return false;
   }
 


### PR DESCRIPTION
I opened an issue (#52) to describe the problem solved in this commit. 
Please let me know if i well understood the Expected Behavior of the "bailable" feature. 

And thank you very much for this awesome repo. 