### PR TITLE
Fix import fileBuffer and make Rules object extensible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-input-validator",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import { Validator } from './validator';
 
 export * as Messages from './messages';
 
-import * as Rules from './rules';
+import * as rules from './rules';
+const Rules = {...rules}
 
 import { Langs, ValidationRuleContract } from './contracts';
 

--- a/src/rules/mime.rule.ts
+++ b/src/rules/mime.rule.ts
@@ -1,7 +1,8 @@
 import { ValidationRuleContract } from "../contracts";
 
 import * as mimeTypes from 'mime-types'
-import { fromBuffer } from 'file-type'
+import fileType from 'file-type'
+const { fromBuffer } = fileType
 import readChunk from 'read-chunk'
 
 export function mime(args: Array<string>, trust: boolean = false): ValidationRuleContract {


### PR DESCRIPTION
This PR is fix two things that break this library in esmodule mode.

- fix: destruct import of fromBuffer from fileType for esm support
currently this error happen because file-type is commonjs module, so we must destruct it
```bash
import { fromBuffer } from 'file-type';
         ^^^^^^^^^^
SyntaxError: The requested module 'file-type' is expected to be of type CommonJS, which does not support named exports. CommonJS modules can be imported by importing the default export.
For example:
import pkg from 'file-type';
const { fromBuffer } = pkg;
    at ModuleJob._instantiate (internal/modules/esm/module_job.js:97:21)
    at async ModuleJob.run (internal/modules/esm/module_job.js:135:5)
    at async Loader.import (internal/modules/esm/loader.js:178:24)
```

- fix: make Rules object extensible
This error happens when I extend Rule with extend function. Rules object is currently not extensible. We must clone it before to make it extensible
```bash
Rules[ruleName] = ruleFunc;
                    ^
TypeError: Cannot add property even, object is not extensible
```
